### PR TITLE
Feature magicscope

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -175,8 +175,6 @@ PHP_INI_BEGIN()
         OnUpdateBool, check_recursion, zend_blitz_globals, blitz_globals)
     STD_PHP_INI_ENTRY("blitz.scope_lookup_limit", "0", PHP_INI_ALL,
         OnUpdateLongLegacy, scope_lookup_limit, zend_blitz_globals, blitz_globals)
-    STD_PHP_INI_ENTRY("blitz.enable_magic_scope", "0", PHP_INI_ALL,
-        OnUpdateBool, enable_magic_scope, zend_blitz_globals, blitz_globals)
     STD_PHP_INI_ENTRY("blitz.lower_case_method_names", "1", PHP_INI_ALL,
         OnUpdateBool, lower_case_method_names, zend_blitz_globals, blitz_globals)
     STD_PHP_INI_ENTRY("blitz.enable_include", "1", PHP_INI_ALL,
@@ -696,7 +694,6 @@ static void php_blitz_init_globals(zend_blitz_globals *blitz_globals) /* {{{ */
     blitz_globals->tag_comment_open = BLITZ_TAG_COMMENT_OPEN;
     blitz_globals->tag_comment_close = BLITZ_TAG_COMMENT_CLOSE;
     blitz_globals->scope_lookup_limit = 0;
-    blitz_globals->enable_magic_scope = 0;
     blitz_globals->auto_escape = 0;
     blitz_globals->throw_exceptions = 0;
 }
@@ -2340,13 +2337,13 @@ static inline unsigned int blitz_fetch_var_by_path(zval ***zparam, const char *l
             key[key_len] = '\x0';
 
             /* try to get data by the key */
-            if (BLITZ_G(enable_magic_scope) && BLITZ_IS_PREDEFINED_TOP(key, key_len)) {
-                if (BLITZ_DEBUG) php_printf("magic_scope: resetting stack key '%s' in scope::%lu -> 0\n", key, magic_stack);
+            if (BLITZ_IS_PREDEFINED_TOP(key, key_len)) {
+                if (BLITZ_DEBUG) php_printf("predefined path _top: resetting stack key '%s' in scope::%lu -> 0\n", key, magic_stack);
                 magic_stack = 0;
                 *zparam = &tpl->scope_stack[magic_stack];
-            } else if (BLITZ_G(enable_magic_scope) && BLITZ_IS_PREDEFINED_PARENT(key, key_len)) {
+            } else if (BLITZ_IS_PREDEFINED_PARENT(key, key_len)) {
                 magic_offset = (tpl->scope_stack_pos == magic_stack ? 2 : 1); /* if we're at the initial stack level, subtract 2 to get to the parent, since we just created a new stack level */
-                if (BLITZ_DEBUG) php_printf("magic_scope: resetting stack key '%s' in scope::%lu -> %lu\n", key, magic_stack, (magic_stack > magic_offset ? magic_stack - magic_offset : 0));
+                if (BLITZ_DEBUG) php_printf("predefined path _parent: resetting stack key '%s' in scope::%lu -> %lu\n", key, magic_stack, (magic_stack > magic_offset ? magic_stack - magic_offset : 0));
                 magic_stack = (magic_stack > magic_offset ? magic_stack - magic_offset : 0); /* keep track of the current magic scope to enable things like _parent._parent */
                 *zparam = &tpl->scope_stack[magic_stack];
             } else if (0 == root_found) { /* globals or params? */
@@ -3456,9 +3453,7 @@ static int blitz_exec_nodes(blitz_tpl *tpl, blitz_node *first_child,
         }
     }
 
-    if (BLITZ_G(scope_lookup_limit) || BLITZ_G(enable_magic_scope)) {
-        BLITZ_SCOPE_STACK_PUSH(tpl, parent_params);
-    }
+    BLITZ_SCOPE_STACK_PUSH(tpl, parent_params);
 
     node = first_child;
     while (node) {
@@ -3530,9 +3525,7 @@ static int blitz_exec_nodes(blitz_tpl *tpl, blitz_node *first_child,
         }
     }
 
-    if (BLITZ_G(scope_lookup_limit) || BLITZ_G(enable_magic_scope)) {
-        BLITZ_SCOPE_STACK_SHIFT(tpl);
-    }
+    BLITZ_SCOPE_STACK_SHIFT(tpl);
 
     if (BLITZ_DEBUG)
         php_printf("== D:b3  %ld,%ld,%ld\n",last_close,parent_begin,parent_end);

--- a/php_blitz.h
+++ b/php_blitz.h
@@ -62,7 +62,6 @@ ZEND_BEGIN_MODULE_GLOBALS(blitz)
     char warn_context_duplicates;
     char check_recursion;
     unsigned long scope_lookup_limit;
-    char enable_magic_scope;
     char lower_case_method_names;
     char auto_escape;
     char throw_exceptions;

--- a/tests/scope4.phpt
+++ b/tests/scope4.phpt
@@ -50,50 +50,10 @@ $data = array(
     'currentUserName' => 'Thibaut'
 );
 
-ini_set('blitz.enable_magic_scope', 0);
-$T->display($data);
-ini_set('blitz.enable_magic_scope', 1);
 $T->display($data);
 
 ?>
 --EXPECT--
-Name: Vincent 
-Friends:
-  Name: Maurus 
-  Friends:
-      Name: Thibaut 
-      Name: Vincent 
-      Name: Nicolas 
-  Name: Thibaut 
-  Friends:
-      Name: Vincent 
-  Name: Vincent 
-  Friends:
-      Name: Maurus 
-      Name: Thibaut 
-      Name: Vincent 
-Name: Maurus 
-Friends:
-  Name: Thibaut 
-  Friends:
-      Name: Vincent 
-  Name: Vincent 
-  Friends:
-      Name: Maurus 
-      Name: Thibaut 
-      Name: Vincent 
-  Name: Nicolas 
-  Friends:
-Name: Thibaut 
-Friends:
-  Name: Vincent 
-  Friends:
-      Name: Maurus 
-      Name: Thibaut 
-      Name: Vincent 
-Name: Nicolas 
-Friends:
-===================================================================
 Name: Vincent 
 Friends:
   Name: Maurus 


### PR DESCRIPTION
Added the magic scope feature: _top and _parent (only if you enable it by setting blitz.enable_magic_scope = 1 in the ini)

The following should work:

```
$data = [ "users" => [ [ "name" => "john", "id" => 1 ], [ "name" => "bart", "id" => 2 ] ], "currentUser" => 2 ];

{{ BEGIN users }}
  name: {{ name }} {{ IF id == _parent.currentUser }} That's me! {{ END }}
{{ END users }}
```

_parent goes up in the stack and _top goes to the beginning of the stack.
Check tests/scope4.phpt for a more detailed example.
