### PR TITLE
Fixed issue #20

### DIFF
--- a/tests/complex_conditions5.phpt
+++ b/tests/complex_conditions5.phpt
@@ -1,0 +1,82 @@
+--TEST--
+expressions with null and strings
+--FILE--
+<?php
+include('common.inc');
+ini_set('blitz.remove_spaces_around_context_tags', 1);
+
+$body = <<<BODY
+<select name="type">
+{{BEGIN types}}
+	<option id="{{id}}" {{IF _parent.type == name}}selected="selected"{{END}}>{{name}}</option>
+	<option id="second_{{id}}" {{IF _parent.type && _parent.type == name}}selected="selected"{{END}}>{{name}}</option>
+{{END}}
+</select>
+
+BODY;
+
+$types = array(
+	array('id' => 1, 'name' => 'House'),
+	array('id' => 2, 'name' => 'Land'),
+	array('id' => 3, 'name' => 'Flat'),
+	array('id' => 4, 'name' => 'Garage')
+);
+
+$T = new Blitz();
+$T->load($body);
+
+// run 1, no assigns
+$T->display(
+	array(
+		'types' => $types
+	)
+);
+
+// run 2, null assign
+$T->display(
+	array(
+		'types' => $types,
+		'type' => null
+	)
+);
+
+// run 3, full assign
+$T->display(
+	array(
+		'types' => $types,
+		'type' => 'Land'
+	)
+);
+
+?>
+--EXPECT--
+<select name="type">
+	<option id="1" >House</option>
+	<option id="second_1" >House</option>
+	<option id="2" >Land</option>
+	<option id="second_2" >Land</option>
+	<option id="3" >Flat</option>
+	<option id="second_3" >Flat</option>
+	<option id="4" >Garage</option>
+	<option id="second_4" >Garage</option>
+</select>
+<select name="type">
+	<option id="1" >House</option>
+	<option id="second_1" >House</option>
+	<option id="2" >Land</option>
+	<option id="second_2" >Land</option>
+	<option id="3" >Flat</option>
+	<option id="second_3" >Flat</option>
+	<option id="4" >Garage</option>
+	<option id="second_4" >Garage</option>
+</select>
+<select name="type">
+	<option id="1" >House</option>
+	<option id="second_1" >House</option>
+	<option id="2" selected="selected">Land</option>
+	<option id="second_2" selected="selected">Land</option>
+	<option id="3" >Flat</option>
+	<option id="second_3" >Flat</option>
+	<option id="4" >Garage</option>
+	<option id="second_4" >Garage</option>
+</select>

--- a/tests/if_expr4.phpt
+++ b/tests/if_expr4.phpt
@@ -1,0 +1,137 @@
+--TEST--
+testing numbers
+--FILE--
+<?php
+include('common.inc');
+ini_set('blitz.remove_spaces_around_context_tags', 1);
+
+$body = <<<BODY
+{{IF a == b}}a equals b{{ELSE}}a doesn't equals b{{END}}
+{{IF c > d}}c is bigger then d{{ELSE}}c not bigger then d{{END}}
+{{IF e >= f}}e is bigger or equal to f{{ELSE}}e not bigger or equal to f{{END}}
+---
+
+BODY;
+
+$T = new Blitz();
+$T->load($body);
+
+// run 1, empty
+$T->display(
+	array(
+	)
+);
+
+// run 2, null assign
+$T->display(
+	array(
+		'a' => null,
+		'b' => null,
+		'c' => null,
+		'd' => null,
+		'e' => null,
+		'f' => null
+	)
+);
+
+// run 3, playtime
+$T->display(
+	array(
+		'a' => 5,
+		'b' => 5,
+		'c' => 5,
+		'd' => 5,
+		'e' => 5,
+		'f' => 5
+	)
+);
+
+$T->display(
+	array(
+		'a' => 5.0,
+		'b' => 5,
+		'c' => 5.0,
+		'd' => 5,
+		'e' => 5.0,
+		'f' => 5
+	)
+);
+
+$T->display(
+	array(
+		'a' => 5.0,
+		'b' => 5.0,
+		'c' => 5.0,
+		'd' => 5.0,
+		'e' => 5.0,
+		'f' => 5.0
+	)
+);
+
+$T->display(
+	array(
+		'a' => "5",
+		'b' => 5.0,
+		'c' => "5.0",
+		'd' => 5.0,
+		'e' => "5.0",
+		'f' => 5.0
+	)
+);
+
+$T->display(
+	array(
+		'a' => "5",
+		'b' => 5,
+		'c' => "5",
+		'd' => 5,
+		'e' => "5",
+		'f' => 5
+	)
+);
+
+$T->display(
+	array(
+		'a' => "5ve",
+		'b' => 5,
+		'c' => "0 ducks",
+		'd' => 0,
+		'e' => "5.ve",
+		'f' => 5.0
+	)
+);
+
+?>
+--EXPECT--
+a doesn't equals b
+c not bigger then d
+e not bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---
+a equals b
+c not bigger then d
+e is bigger or equal to f
+---

--- a/tests/if_expr5.phpt
+++ b/tests/if_expr5.phpt
@@ -1,0 +1,112 @@
+--TEST--
+testing not operator
+--FILE--
+<?php
+include('common.inc');
+ini_set('blitz.remove_spaces_around_context_tags', 1);
+
+$body = <<<BODY
+{{IF !a}}not a{{ELSE}}a{{END}}
+{{IF !!a}}not not a{{ELSE}}not a{{END}}
+---
+
+BODY;
+
+$T = new Blitz();
+$T->load($body);
+
+// run 1, empty
+$T->display(
+	array(
+	)
+);
+
+// run 2, null assign
+$T->display(
+	array(
+		'a' => null
+	)
+);
+
+// run 3, boolean
+$T->display(
+	array(
+		'a' => true
+	)
+);
+
+$T->display(
+	array(
+		'a' => false
+	)
+);
+
+// run 4, strings / doubles / everything else
+$T->display(
+	array(
+		'a' => ""
+	)
+);
+
+$T->display(
+	array(
+		'a' => "not empty"
+	)
+);
+
+$T->display(
+	array(
+		'a' => "0 ducks"
+	)
+);
+
+$T->display(
+	array(
+		'a' => "1 rabbit"
+	)
+);
+
+$T->display(
+	array(
+		'a' => 0.0
+	)
+);
+
+$T->display(
+	array(
+		'a' => 0.2
+	)
+);
+
+?>
+--EXPECT--
+not a
+not a
+---
+not a
+not a
+---
+a
+not not a
+---
+not a
+not a
+---
+not a
+not a
+---
+a
+not not a
+---
+a
+not not a
+---
+a
+not not a
+---
+not a
+not a
+---
+a
+not not a
+---


### PR DESCRIPTION
Basically, when you're comparing 2 operands in the IF, and one of them is a
BOOL, fall back to the boolean comparison, and not the double comparison.

PHP supports type juggling, so does blitz. If you compare 3.0 with the string
"3", this results in a true, as well if you compare 0 with the string "0".
To enable this, we cast the string "3" to a double, with the atof system call.
It's very similar to intval() in PHP. But, when your string doesn't start with
a number, it returns double value 0.0.

So, when you have the string "house", it's double value is 0.0. If you compare
it with a boolean operator TRUE, you'll get a mismatch since 0.0 != 1.0.

So, whenever we encounter a BOOL operator now, we use the boolean value. For a
string this is checking if it's length is non-zero.