### PR TITLE
fix potential memory corruption

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -5015,7 +5015,7 @@ static inline int blitz_merge_iterations_by_str_keys(zval *target, zval *input) 
             zval tmp;
             ZVAL_COPY_VALUE(&tmp, elem);
             zval_copy_ctor(&tmp);
-            zend_hash_update(HASH_OF(target), key, &tmp);
+            zend_hash_str_update(HASH_OF(target), key->val, key->len, &tmp);
         }
         zend_hash_move_forward(input_ht);
     }
@@ -5346,7 +5346,7 @@ static PHP_FUNCTION(blitz_set_global)
         ZVAL_COPY_VALUE(&temp, elem);
         zval_copy_ctor(&temp);
 
-        zend_hash_update(tpl->hash_globals, key, &temp);
+        zend_hash_str_update(tpl->hash_globals, key->val, key->len, &temp);
         zend_hash_move_forward(input_ht);
     }
 
@@ -5752,15 +5752,8 @@ static PHP_FUNCTION(blitz_fetch)
     if (input_arr && path_iteration) {
         if (BLITZ_DEBUG) php_printf("merging current iteration and params in fetch\n");
         input_ht = HASH_OF(input_arr);
-        zend_hash_internal_pointer_reset(HASH_OF(path_iteration));
-        zend_hash_internal_pointer_reset(input_ht);
 
-        while ((elem = blitz_hash_get_current_data(input_ht)) != NULL) {
-            if (zend_hash_get_current_key(input_ht, &key, &index) != HASH_KEY_IS_STRING) {
-                zend_hash_move_forward(input_ht);
-                continue;
-            }
-
+        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(input_ht, key, elem) {
             INDIRECT_CONTINUE_FORWARD(input_ht, elem);
 
             if (key && key->len) {
@@ -5769,10 +5762,9 @@ static PHP_FUNCTION(blitz_fetch)
                 ZVAL_COPY_VALUE(&temp, elem);
                 zval_copy_ctor(&temp);
 
-                zend_hash_update(HASH_OF(path_iteration), key, &temp);
+                zend_hash_str_update(HASH_OF(path_iteration), key->val, key->len, &temp);
             }
-            zend_hash_move_forward(input_ht);
-        }
+        } ZEND_HASH_FOREACH_END();
     }
 
     if (BLITZ_DEBUG) {


### PR DESCRIPTION
zend_string keys aren't copied when used in _add or _update, which can (and will) lead to memory corruption.
so.. let's avoid using them completely.

the patch also simplifies a part of the code by using ZEND_HASH_FOREACH macro.