### PR TITLE
Added ability to use literal tags like {{ in the template. 

### DIFF
--- a/tests/explicit_tags.phpt
+++ b/tests/explicit_tags.phpt
@@ -1,0 +1,31 @@
+--TEST--
+testing arithmetics
+--FILE--
+<?php
+include('common.inc');
+ini_set('blitz.remove_spaces_around_context_tags', 1);
+
+$body = <<<BODY
+So, if I ever want to use a tag as a literal in a template, {{var_person}} just have to double it: {{{{test}}}} will appear as {{var_test}} surrounded by 4 curly brackets!
+We can go crazy {{{{{{{{{{{{{{{{ about it }}}} {{var_wicked}}
+But just }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}} will work smooth
+We can even do {{{{ {{var_person}} }}}} which will result in I surrounded by 2 curly brackets on each side
+
+BODY;
+
+$T = new Blitz();
+$T->load($body);
+
+$T->display(
+	array(
+		'var_person' => 'I',
+		'var_test' => 'test',
+		'var_wicked' => 'Wicked!'
+	)
+);
+?>
+--EXPECT--
+So, if I ever want to use a tag as a literal in a template, I just have to double it: {{test}} will appear as test surrounded by 4 curly brackets!
+We can go crazy {{{{{{{{ about it }} Wicked!
+But just }}}}}}}}}}}}}}}} will work smooth
+We can even do {{ I }} which will result in I surrounded by 2 curly brackets on each side


### PR DESCRIPTION
Just repeat them twice to 'escape' them.

So if you use {{{{ in a template, it will become {{. Handy if you like to preserve compatibility with handlebarsjs.com etc.

Right now adding {{{{ will result in a parse error.
What do you guys think of this? Please let me know the comments and concerns. I didn't want to add escaping since {{ or {{ since this might break existing stuff, that's why I've chosen to repeat them twice.

Also works for all other tags. It's a pretty simple commit.
