### PR TITLE
Remove (PHP7) from the version string

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -17,7 +17,7 @@
 */
 
 #define BLITZ_DEBUG 0
-#define BLITZ_VERSION_STRING "0.10.3 (PHP7)"
+#define BLITZ_VERSION_STRING "0.10.3"
 
 #ifndef PHP_WIN32
 #include <sys/mman.h>


### PR DESCRIPTION
This is causing some issues when requiring a minimum version in `composer.json`:

```
 - The requested PHP extension ext-blitz >=0.9.1 has the wrong version (0.10.3 (PHP7)) installed.
```