### PR TITLE
fix crash on empty template, add test

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -420,7 +420,9 @@ static blitz_tpl *blitz_init_tpl_base(HashTable *globals, zval *iterations, blit
 
 
     static_data = & tpl->static_data;
-    static_data->body.a = 0;
+    /* make sure body is always not-NULL */
+    smart_str_alloc(&static_data->body, 1, 0);
+    smart_str_0(&static_data->body);
 
     tpl->flags = 0;
     static_data->n_nodes = 0;
@@ -2597,7 +2599,7 @@ static inline int blitz_analize (blitz_tpl *tpl) /* {{{ */
         },
     };
 
-    if (!tpl->static_data.body.s) {
+    if (!ZSTR_LEN(tpl->static_data.body.s)) {
         return 0;
     }
 
@@ -5213,7 +5215,7 @@ static PHP_FUNCTION(blitz_load)
         return;
     }
 
-    if (tpl->static_data.body.s) {
+    if (ZSTR_LEN(tpl->static_data.body.s)) {
         blitz_error(tpl, E_WARNING, "INTERNAL ERROR: template is already loaded");
         RETURN_FALSE;
     }
@@ -5413,8 +5415,8 @@ static PHP_FUNCTION(blitz_parse)
         return;
     }
 
-    if (!tpl->static_data.body.s) { /* body was not loaded */
-        RETURN_FALSE;
+    if (!ZSTR_LEN(tpl->static_data.body.s)) { /* body was not loaded */
+        RETURN_EMPTY_STRING();
     }
 
     if (input_arr && 0 < zend_hash_num_elements(HASH_OF(input_arr))) {
@@ -5448,8 +5450,8 @@ static PHP_FUNCTION(blitz_display)
         return;
     }
 
-    if (!tpl->static_data.body.s) { /* body was not loaded */
-        RETURN_FALSE;
+    if (!ZSTR_LEN(tpl->static_data.body.s)) { /* body was not loaded */
+        RETURN_EMPTY_STRING();
     }
 
     if (input_arr && 0 < zend_hash_num_elements(HASH_OF(input_arr))) {

--- a/tests/empty_template.phpt
+++ b/tests/empty_template.phpt
@@ -1,0 +1,47 @@
+--TEST--
+empty template test 
+--FILE--
+<?php
+
+$t = new Blitz(__DIR__."/empty.tpl");
+
+var_dump($t->parse());
+var_dump($t->fetch("/"));
+var_dump($t->display());
+var_dump($t->getTokens());
+var_dump($t->iterate('/main'));
+var_dump($t->context('/main/first'));
+var_dump($t->block('5588/lklk'));
+var_dump($t->iterate('5588/lklk'));
+
+$t = new Blitz();
+
+var_dump($t->parse());
+var_dump($t->fetch("/"));
+var_dump($t->display());
+var_dump($t->getTokens());
+var_dump($t->iterate('/main'));
+var_dump($t->context('/main/first'));
+var_dump($t->block('5588/lklk'));
+var_dump($t->iterate('5588/lklk'));
+
+?>
+--EXPECTF--
+string(0) ""
+string(0) ""
+string(0) ""
+array(0) {
+}
+bool(true)
+string(1) "/"
+bool(true)
+bool(true)
+string(0) ""
+string(0) ""
+string(0) ""
+array(0) {
+}
+bool(true)
+string(1) "/"
+bool(true)
+bool(true)


### PR DESCRIPTION
Short patch to fix reproducible crash with empty template introduced with my smart_str (re)implementation.