### PR TITLE
Php8 support fix

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -2861,7 +2861,7 @@ static inline int blitz_exec_wrapper(blitz_tpl *tpl, smart_str *result, unsigned
             return 0;
         }
 
-        result->s = php_escape_html_entities_ex((unsigned char *)args[0], args_len[0], all, quote_style, SG(default_charset), 1);
+        result->s = php_escape_html_entities_ex((unsigned char *)args[0], args_len[0], all, quote_style, SG(default_charset), 1, 0);
         result->a = ZSTR_LEN(result->s);
 
     } else if (type == BLITZ_NODE_TYPE_WRAPPER_DATE) {
@@ -3582,7 +3582,7 @@ static inline void blitz_exec_var(
 #else
             long quote_style = ENT_QUOTES;
 #endif
-            escaped = php_escape_html_entities_ex((unsigned char *) Z_STRVAL_P(zparam), Z_STRLEN_P(zparam), 0, quote_style, SG(default_charset), 1);
+            escaped = php_escape_html_entities_ex((unsigned char *) Z_STRVAL_P(zparam), Z_STRLEN_P(zparam), 0, quote_style, SG(default_charset), 1, 0);
 
             if (escape_mode == BLITZ_ESCAPE_NL2BR) {
                 char *escaped_str;

--- a/blitz.c
+++ b/blitz.c
@@ -3397,10 +3397,10 @@ static inline int blitz_exec_user_method(blitz_tpl *tpl, blitz_node *node, zval 
 
     function_table = &Z_OBJCE_P(obj)->function_table;
     if (node->namespace_code == BLITZ_NODE_THIS_NAMESPACE) {
-        method_res = call_user_function_ex(function_table, obj, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+        method_res = call_user_function(function_table, obj, &zmethod, &retval, node->n_args, pargs);
     } else if (node->namespace_code) {
         if (BLITZ_G(enable_php_callbacks)) {
-            method_res = call_user_function_ex(NULL, NULL, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+            method_res = call_user_function(NULL, NULL, &zmethod, &retval, node->n_args, pargs);
         } else {
             blitz_error(tpl, E_WARNING,
                 "PHP callbacks are disabled by blitz.enable_php_callbacks, %s call was ignored, line %lu, pos %lu",
@@ -3411,14 +3411,14 @@ static inline int blitz_exec_user_method(blitz_tpl *tpl, blitz_node *node, zval 
         }
     } else {
         if (BLITZ_G(php_callbacks_first) && BLITZ_G(enable_php_callbacks)) {
-            method_res = call_user_function_ex(NULL, NULL, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+            method_res = call_user_function(NULL, NULL, &zmethod, &retval, node->n_args, pargs);
             if (method_res == FAILURE) {
-                method_res = call_user_function_ex(function_table, obj, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+                method_res = call_user_function(function_table, obj, &zmethod, &retval, node->n_args, pargs);
             }
         } else {
-            method_res = call_user_function_ex(function_table, obj, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+            method_res = call_user_function(function_table, obj, &zmethod, &retval, node->n_args, pargs);
             if (method_res == FAILURE && BLITZ_G(enable_php_callbacks)) {
-                method_res = call_user_function_ex(NULL, NULL, &zmethod, &retval, node->n_args, pargs, 1, NULL);
+                method_res = call_user_function(NULL, NULL, &zmethod, &retval, node->n_args, pargs);
             }
         }
     }
@@ -3951,7 +3951,7 @@ static inline void blitz_check_expr (
                 ZVAL_UNDEF(&retval);
 
                 if (BLITZ_G(enable_php_callbacks)) {
-                    method_res = call_user_function_ex(&Z_OBJCE_P(id)->function_table, id, &zmethod, &retval, operands_needed, args, 1, NULL);
+                    method_res = call_user_function(&Z_OBJCE_P(id)->function_table, id, &zmethod, &retval, operands_needed, args);
                 } else {
                     method_res = FAILURE;
                     blitz_error(tpl, E_WARNING,

--- a/blitz.c
+++ b/blitz.c
@@ -324,7 +324,7 @@ static void blitz_error (blitz_tpl *tpl, unsigned int level, char *format, ...) 
     php_error_docref(NULL, level, "%s", msg);
 
     if (BLITZ_G(throw_exceptions) && level == E_WARNING) {
-        zend_throw_exception_ex(zend_exception_get_default(TSRMLS_C), 0, "%s", msg);
+        zend_throw_exception_ex(zend_exception_get_default(), 0, "%s", msg);
     }
 
     if (free_msg) {
@@ -1559,7 +1559,7 @@ static inline void blitz_parse_if (char *text, unsigned int len_text, blitz_node
 
 /* {{{ void blitz_parse_scope() */
 static inline void blitz_parse_scope (char *text, unsigned int len_text, blitz_node *node, char var_prefix,
-    unsigned int *pos_out, char *error_out TSRMLS_DC)
+    unsigned int *pos_out, char *error_out)
 {
     char *c = text;
     unsigned int pos = 0, i_pos = 0, i_len = 0, key_len = 0;
@@ -1883,7 +1883,7 @@ static inline void blitz_parse_call (char *text, unsigned int len_text, blitz_no
                     BLITZ_SKIP_BLANK(c,i_pos,pos);
                     is_path = i_len = i_pos = i_type = 0;
 
-                    blitz_parse_scope(c, len_text-pos, node, var_prefix, &i_pos, error TSRMLS_CC);
+                    blitz_parse_scope(c, len_text-pos, node, var_prefix, &i_pos, error);
                     if (*error != 0) {
                         return;
                     }
@@ -3335,7 +3335,7 @@ static inline int blitz_exec_user_method(blitz_tpl *tpl, blitz_node *node, zval 
 
             if (i_arg_type == BLITZ_ARG_TYPE_VAR) {
                 predefined = -1;
-                found = blitz_extract_var(tpl, i_arg->name, i_arg->len, 0, iteration_params, &predefined, &ztmp TSRMLS_CC);
+                found = blitz_extract_var(tpl, i_arg->name, i_arg->len, 0, iteration_params, &predefined, &ztmp);
                 if (predefined >= 0) {
                     ZVAL_LONG(&arg, (long)predefined);
                 } else if (found) {

--- a/php_blitz.h
+++ b/php_blitz.h
@@ -701,7 +701,7 @@ typedef struct _blitz_analizer_ctx {
         i_len = 1;                                                                                  \
     }                                                                                               \
 
-typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_CC);
+typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval *);
 
 #define BLITZ_OPERATOR_TO_ZEND_NATIVE_FUNCTION(op)                                                  \
     ( (op == BLITZ_EXPR_OPERATOR_ADD) ? add_function :                                              \
@@ -818,7 +818,7 @@ typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_
                                                                                                   \
     desc = zend_hash_str_find(Z_OBJPROP_P((id)), "tpl", sizeof("tpl") - 1);                       \
     if (!desc || Z_TYPE_P(desc) != IS_RESOURCE) {                                                 \
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,                                               \
+        php_error_docref(NULL, E_WARNING,                                               \
             "INTERNAL: template was not loaded/initialized (cannot find template descriptor)"     \
         );                                                                                        \
         RETURN_FALSE;                                                                             \
@@ -834,7 +834,7 @@ typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_
 /* loop stack tricks */
 #define BLITZ_LOOP_MOVE_FORWARD(tpl)                                                              \
     if (tpl->loop_stack_level>=BLITZ_LOOP_STACK_MAX) {                                            \
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,                                               \
+        php_error_docref(NULL, E_WARNING,                                               \
             "INTERNAL ERROR: loop stack limit (%u) was exceeded, recompile blitz "                \
             "with BLITZ_LOOP_STACK_MAX increased", BLITZ_LOOP_STACK_MAX);                         \
     } else {                                                                                      \
@@ -856,7 +856,7 @@ typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_
         tpl->scope_stack[tpl->scope_stack_pos] = data;                                            \
         tpl->scope_stack_pos++;                                                                   \
     } else {                                                                                      \
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,                                               \
+        php_error_docref(NULL, E_WARNING,                                               \
             "Too deep iteration set, lookup scope depth is too high, lookup stack is broken "     \
             "and variables can be resolved improperly. To fix this rebuild blitz extension with " \
             "increased BLITZ_SCOPE_STACK_MAX constant in php_blitz.h"                             \
@@ -870,7 +870,7 @@ typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_
     if (tpl->scope_stack_pos > 0) {                                                               \
         tpl->scope_stack_pos--;                                                                   \
     } else {                                                                                      \
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,                                               \
+        php_error_docref(NULL, E_WARNING,                                               \
             "Too deep iteration set, lookup scope depth is too high, lookup stack is broken "     \
             "and variables can be resolved improperly. To fix this rebuild blitz extension with " \
             "increased BLITZ_SCOPE_STACK_MAX constant in php_blitz.h"                             \
@@ -884,7 +884,7 @@ typedef int (ZEND_FASTCALL *zend_native_function)(zval *, zval *, zval * TSRMLS_
         stack[stack_level].len = alen;                                                            \
         stack[stack_level].type = atype;                                                          \
     } else {                                                                                      \
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,                                               \
+        php_error_docref(NULL, E_WARNING,                                               \
             "Too complex conditional, operator stack depth is too high and broken, operators "    \
             "will  be resolved improperly. To fix this rebuild blitz extension with increased "   \
             "BLITZ_IF_STACK_MAX constant in php_blitz.h"                                          \

--- a/tests/if_expr4.phpt
+++ b/tests/if_expr4.phpt
@@ -131,7 +131,7 @@ a equals b
 c not bigger then d
 e is bigger or equal to f
 ---
-a equals b
-c not bigger then d
+a doesn't equals b
+c is bigger then d
 e is bigger or equal to f
 ---


### PR DESCRIPTION
Hello. Here some fixes for compilation against php-8.0.0.

TSRMLS removed
New parameter for php_escape_html_entities_ex
call_user_function_ex replaced with call_user_function
Fixed test about comparison string to number in if expression

Don't know what to do with `tests/return_non_string.phpt`. There is fatal error in this test under php-8.0.0

Also need branch `php8` to merge