### PR TITLE
Fix Segmentation fault on moving hashtable internal pointer of zend_empty_array

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -5059,6 +5059,7 @@ static inline int blitz_merge_iterations_set(blitz_tpl *tpl, zval *input_arr) /*
     /* set works differently for numerical keys and string keys: */
     /*     (1) STRING: set(array('a' => 'a_val')) will update current_iteration keys */
     /*     (2) LONG: set(array(0=>array('a'=>'a_val'))) will reset current_iteration_parent */
+    SEPARATE_ARRAY(input_arr);
     input_ht = HASH_OF(input_arr);
     zend_hash_internal_pointer_reset(input_ht);
     first_key_type = zend_hash_get_current_key(input_ht, &key, &index);


### PR DESCRIPTION
Sample code

```
<?php

$blitz = new Blitz('template.tpl');
$blitz->set(['CONTENT' => []]);
$blitz->fetch('/CONTENT', []);
```

Backtrace
```
(gdb) bt
#0  zend_hash_internal_pointer_end_ex (ht=0x5555561fdf20 <zend_empty_array>, pos=0x5555561fdf44 <zend_empty_array+36>)
    at /sources/php.git/Zend/zend_hash.c:2353
#1  0x00007ffff4a8939f in blitz_find_iteration_by_path (tpl=0x7ffff507e000, path=0x7ffff5080000 "/CONTENT", path_len=8, iteration=0x7fffffffac08,
    iteration_parent=0x7fffffffac10) at /usr/local/php/include/php/Zend/zend_types.h:556
#2  0x00007ffff4a97588 in zif_blitz_fetch (execute_data=0x7ffff50140d0, return_value=0x7fffffffac98) at /sources/blitz/blitz.c:5717
#3  0x0000555555636151 in ZEND_DO_FCALL_SPEC_OBSERVER_HANDLER () at /sources/php.git/Zend/zend_vm_execute.h:1981
#4  0x000055555563693b in execute_ex (ex=0x5555561fdf20 <zend_empty_array>, ex@entry=0x7ffff5014020) at /sources/php.git/Zend/zend_vm_execute.h:55792
#5  0x00005555559254d6 in dtrace_execute_ex (execute_data=0x7ffff5014020) at /sources/php.git/Zend/zend_dtrace.c:81
#6  0x00005555559b25b0 in zend_execute (op_array=0x7ffff5087000, return_value=0x0) at /sources/php.git/Zend/zend_vm_execute.h:60123
#7  0x000055555593a533 in zend_execute_scripts (type=type@entry=8, retval=retval@entry=0x0, file_count=file_count@entry=3)
    at /sources/php.git/Zend/zend.c:1933
#8  0x00005555558c160a in php_execute_script (primary_file=<optimized out>) at /sources/php.git/main/main.c:2561
#9  0x0000555555a362bf in do_cli (argc=2, argv=0x555558c48b00) at /sources/php.git/sapi/cli/php_cli.c:965
#10 0x0000555555642088 in main (argc=2, argv=0x555558c48b00) at /sources/php.git/sapi/cli/php_cli.c:1371
```

under debug, it also aborts with assert
```
php: /sources/php.git/Zend/zend_hash.c:2330: zend_hash_internal_pointer_reset_ex: Assertion `(&ht->nInternalPointer != pos || zend_gc_refcount(&(ht)->gc) == 1) || ((ht)->u.flags & (1<<6))' failed.

Program received signal SIGABRT, Aborted.
```

Looks like this is due to `const HashTable zend_empty_array` used in some places for optimization.
