### PR TITLE
Arginfo takes 2 arguments

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -5920,6 +5920,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_blitz_block, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_blitz_include, 0, 0, 1)
+    ZEND_ARG_INFO(0, filename)
     ZEND_ARG_INFO(0, input)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
But arginfo tells us about only one of them