### PR TITLE
Avoiding allow_dynamic_properties for PHP prior to 8.2

### DIFF
--- a/blitz.c
+++ b/blitz.c
@@ -5992,7 +5992,9 @@ PHP_MINIT_FUNCTION(blitz) /* {{{ */
     le_blitz = zend_register_list_destructors_ex(blitz_resource_dtor, NULL, "Blitz template", module_number);
 
     INIT_CLASS_ENTRY(blitz_class_entry, "blitz", blitz_functions);
-    blitz_class_entry.ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+    #if PHP_VERSION_ID >= 80200
+        blitz_class_entry.ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+    #endif
     zend_register_internal_class(&blitz_class_entry);
     blitz_register_constants(INIT_FUNC_ARGS_PASSTHRU);
 


### PR DESCRIPTION
Fix build issue with PHP 8.0-8.1, which don't support `ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES` flag.